### PR TITLE
[Haskell] match deriving instance (..) without breaking data deriving

### DIFF
--- a/Haskell/Haskell.sublime-syntax
+++ b/Haskell/Haskell.sublime-syntax
@@ -123,8 +123,6 @@ contexts:
           scope: entity.other.inherited-class.haskell
         - match: '\b[a-z][a-zA-Z0-9_'']*\b'
           scope: variable.other.generic-type.haskell
-    - match: \bderiving\b
-      scope: keyword.declaration.haskell
     - match: \binstance\b
       scope: keyword.declaration.haskell
       push:
@@ -172,6 +170,8 @@ contexts:
     - match: \b(?:newtype|type)\b
       scope: keyword.declaration.type.haskell
     - match: \b(?:data)\b
+      scope: keyword.declaration.data.haskell
+    - match: \b(?:deriving)\b
       scope: keyword.declaration.data.haskell
     - match: \b(?:case|of)\b
       scope: keyword.control.conditional.select.haskell  # the construct is commonly called "select"

--- a/Haskell/syntax_test_haskell.hs
+++ b/Haskell/syntax_test_haskell.hs
@@ -77,6 +77,7 @@
       , recordDouble :: Double
       , recordRational :: Rational
       } deriving (Eq, Ord, Generic)
+--      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.deriving.haskell
         deriving (Read, Show) via (Quiet Record)
 --                            ^^^ keyword.other.haskell
 --                            ^^^^^^^^^^^^^^^^^^ meta.deriving.haskell
@@ -215,9 +216,9 @@ import Data.List.Split (splitOn)
 --                             ^ punctuation.section.group.end.haskell
 
    deriving instance FromJSON Amount
--- ^^^^^^^^ keyword.declaration.haskell
+-- ^^^^^^^^ keyword.declaration.data.haskell
    deriving instance FromJSON Ask
---          ^^^^^^^^ keyword.declaration.haskell
+--          ^^^^^^^^ meta.declaration.instance.haskell keyword.declaration.haskell
 
 test =
 --   ^ keyword.operator.haskell


### PR DESCRIPTION
This fixes a bug introduced via 0d36dd1b18baa0e57474edc1853d901cd1887880