### PR TITLE
[PHP] Add CSS/JS string interpolation

### DIFF
--- a/PHP/CSS (for PHP).sublime-syntax
+++ b/PHP/CSS (for PHP).sublime-syntax
@@ -12,6 +12,30 @@ contexts:
     - meta_prepend: true
     - include: php-embedded
 
+  string-content:
+    - meta_prepend: true
+    - include: php-interpolations
+
+  php-interpolations:
+    - match: <\?(?i:php|=)?(?![^?]*\?>)
+      scope: punctuation.section.embedded.begin.php
+      push: php-interpolation-block
+    - match: <\?(?i:php|=)?
+      scope: punctuation.section.embedded.begin.php
+      push: php-interpolation-line
+
+  php-interpolation-block:
+    - clear_scopes: 1
+    - meta_scope: meta.interpolation.css meta.embedded.block.php
+    - meta_content_scope: source.php.embedded.css
+    - include: php-embedded-content
+
+  php-interpolation-line:
+    - clear_scopes: 1
+    - meta_scope: meta.interpolation.css meta.embedded.line.php
+    - meta_content_scope: source.php.embedded.css
+    - include: php-embedded-content
+
   php-embedded:
     - match: <\?(?i:php|=)?(?![^?]*\?>)
       scope: punctuation.section.embedded.begin.php

--- a/PHP/JavaScript (for PHP).sublime-syntax
+++ b/PHP/JavaScript (for PHP).sublime-syntax
@@ -12,6 +12,30 @@ contexts:
     - meta_prepend: true
     - include: php-embedded
 
+  string-content:
+    - meta_prepend: true
+    - include: php-interpolations
+
+  php-interpolations:
+    - match: <\?(?i:php|=)?(?![^?]*\?>)
+      scope: punctuation.section.embedded.begin.php
+      push: php-interpolation-block
+    - match: <\?(?i:php|=)?
+      scope: punctuation.section.embedded.begin.php
+      push: php-interpolation-line
+
+  php-interpolation-block:
+    - clear_scopes: 1
+    - meta_scope: meta.interpolation.js meta.embedded.block.php
+    - meta_content_scope: source.php.embedded.js
+    - include: php-embedded-content
+
+  php-interpolation-line:
+    - clear_scopes: 1
+    - meta_scope: meta.interpolation.js meta.embedded.line.php
+    - meta_content_scope: source.php.embedded.js
+    - include: php-embedded-content
+
   php-embedded:
     - match: <\?(?i:php|=)?(?![^?]*\?>)
       scope: punctuation.section.embedded.begin.php

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -2075,6 +2075,21 @@ var_dump(new C(42));
 //      ^^ meta.embedded.block.php - source.php
     }
     ?>
+
+    bar = "foo<?php echo "bar"; ?>baz"
+//        ^^^^ source.js.embedded.html meta.string.js - meta.interpolation - meta.embedded
+//            ^^^^^ source.js.embedded.html meta.string.js meta.interpolation.js meta.embedded.line.php - source.php.embedded.js
+//                 ^^^^^^^^^^^^^ source.js.embedded.html meta.string.js meta.interpolation.js meta.embedded.line.php source.php.embedded.js
+//                              ^^ source.js.embedded.html meta.string.js meta.interpolation.js meta.embedded.line.php - source.php.embedded.js
+//        ^^^^ string.quoted.double.js
+//            ^^^^^^^^^^^^^^^^^^^^ - string.quoted.double.js
+//            ^^^^^ punctuation.section.embedded.begin.php
+//                  ^^^^ support.function.construct.php
+//                       ^^^^^ string.quoted.double.php
+//                            ^ punctuation.terminator.expression.php
+//                              ^^ punctuation.section.embedded.end.php
+//                                ^^^^ string.quoted.double.js
+
 </script>
 <style>
 h1 {
@@ -2097,5 +2112,19 @@ h1 {
 //      ^^^^ support.type.property-name
 //            ^ constant.numeric
     <? } ?>
+
+    font-family: "foo<?php echo "bar"; ?>baz";
+//               ^^^^ source.css.embedded.html meta.string.css - meta.interpolation - meta.embedded
+//                   ^^^^^ source.css.embedded.html meta.string.css meta.interpolation.css meta.embedded.line.php - source.php.embedded.css
+//                        ^^^^^^^^^^^^^ source.css.embedded.html meta.string.css meta.interpolation.css meta.embedded.line.php source.php.embedded.css
+//                                     ^^ source.css.embedded.html meta.string.css meta.interpolation.css meta.embedded.line.php - source.php.embedded.css
+//               ^^^^ string.quoted.double.css
+//                   ^^^^^^^^^^^^^^^^^^^^ - string.quoted.double.css
+//                   ^^^^^ punctuation.section.embedded.begin.php
+//                         ^^^^ support.function.construct.php
+//                              ^^^^^ string.quoted.double.php
+//                                   ^ punctuation.terminator.expression.php
+//                                     ^^ punctuation.section.embedded.end.php
+//                                       ^^^^ string.quoted.double.css
 }
 </style>


### PR DESCRIPTION
This PR adds php interpolation to `string-content` contexts of CSS/JS.

While working on Ruby on Rails I realized both CSS and JavaScript provide `string-content` context, which can be used to add proper sting interpolation support with regards to embedded sources.

We may want to make use of it in PHP as well.